### PR TITLE
refactor: Apply be instead of assert

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alecthomas/assert/v2"
+	"github.com/carlmjohnson/be"
 	"github.com/raeperd/realworld"
 )
 
@@ -14,15 +14,15 @@ func TestAuth(t *testing.T) {
 	service := realworld.NewJWTService([]byte("secret"))
 
 	token, err := service.Serialize(claim)
-	assert.NoError(t, err)
-	assert.NotZero(t, token)
-	assert.True(t, strings.HasPrefix(token, service.Header()), "token should start with header but got '%s'", token)
+	be.NilErr(t, err)
+	be.Nonzero(t, token)
+	be.True(t, strings.HasPrefix(token, service.Header()))
 
 	after, err := service.Deserialize(token)
-	assert.NoError(t, err)
-	assert.Equal(t, claim, after)
+	be.NilErr(t, err)
+	be.Equal(t, claim, after)
 
 	token2, err := service.Serialize(after)
-	assert.NoError(t, err)
-	assert.Equal(t, token, token2)
+	be.NilErr(t, err)
+	be.Equal(t, token, token2)
 }

--- a/cmd/app/main_test.go
+++ b/cmd/app/main_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alecthomas/assert/v2"
+	"github.com/carlmjohnson/be"
 	"github.com/carlmjohnson/requests"
 )
 
@@ -31,9 +31,9 @@ func TestRun(t *testing.T) {
 		var res HealthCheckResponse
 		err := requests.URL(address).Path("./health").ToJSON(&res).Fetch(ctx)
 
-		assert.NoError(t, err)
-		assert.NotZero(t, res.LastCommitHash)
-		assert.NotZero(t, res.LastCommitTimestamp)
+		be.NilErr(t, err)
+		be.Nonzero(t, res.LastCommitHash)
+		be.Nonzero(t, res.LastCommitTimestamp)
 	})
 
 	t.Run("POST /api/users", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestRun(t *testing.T) {
 				CheckStatus(422).
 				Fetch(ctx)
 
-			assert.NoError(t, err, "%s in case %v", err, tc)
+			be.NilErr(t, err)
 		}
 
 		req := PostUserRequestBody{
@@ -73,8 +73,8 @@ func TestRun(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, req.User.Name, res.User.Name)
-		assert.Equal(t, req.User.Email, res.User.Email)
+		be.Equal(t, req.User.Name, res.User.Name)
+		be.Equal(t, req.User.Email, res.User.Email)
 		// TODO: Delete the user after the test
 	})
 
@@ -93,7 +93,7 @@ func TestRun(t *testing.T) {
 				BodyJSON(&PostUserLoginRequestBody{User: tc}).ToJSON(&res).
 				CheckStatus(422).Fetch(ctx)
 
-			assert.NoError(t, err, "%s in case %v", err, tc)
+			be.NilErr(t, err)
 		}
 
 		req := PostUserLoginRequestBody{
@@ -106,9 +106,9 @@ func TestRun(t *testing.T) {
 		err := requests.URL(address).Path("./api/users/login").
 			BodyJSON(&req).ToJSON(&res).Fetch(ctx)
 
-		assert.NoError(t, err)
-		assert.Equal(t, req.User.Email, res.User.Email)
-		assert.NotZero(t, res.User.Token)
+		be.NilErr(t, err)
+		be.Equal(t, req.User.Email, res.User.Email)
+		be.Nonzero(t, res.User.Token)
 
 		token = res.User.Token
 		// TODO: Delete the user after the test
@@ -116,31 +116,31 @@ func TestRun(t *testing.T) {
 
 	t.Run("GET /api/user", func(t *testing.T) {
 		err := requests.URL(address).Path("./api/user").CheckStatus(401).Fetch(ctx)
-		assert.NoError(t, err)
+		be.NilErr(t, err)
 
 		err = requests.URL(address).Path("./api/user").
 			Header("Authorization", "Token invalid-token").
 			CheckStatus(422).Fetch(ctx)
-		assert.NoError(t, err)
+		be.NilErr(t, err)
 
 		var res PostUserResponseBody
 		err = requests.URL(address).Path("./api/user").
 			Header("Authorization", "Token "+token).
 			CheckStatus(200).ToJSON(&res).Fetch(ctx)
 
-		assert.NoError(t, err)
-		assert.Equal(t, token, res.User.Token)
+		be.NilErr(t, err)
+		be.Equal(t, token, res.User.Token)
 	})
 
 	t.Run("GET /api/profiles/{username}", func(t *testing.T) {
 		username := "username"
 		err := requests.URL(address).Path("./api/profiles/" + username).
 			CheckStatus(200).Fetch(ctx)
-		assert.NoError(t, err)
+		be.NilErr(t, err)
 
 		err = requests.URL(address).Path("./api/profiles/invalid-username").
 			CheckStatus(404).Fetch(ctx)
-		assert.NoError(t, err)
+		be.NilErr(t, err)
 	})
 
 }

--- a/cmd/app/main_test.go
+++ b/cmd/app/main_test.go
@@ -132,6 +132,17 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, token, res.User.Token)
 	})
 
+	t.Run("GET /api/profiles/{username}", func(t *testing.T) {
+		username := "username"
+		err := requests.URL(address).Path("./api/profiles/" + username).
+			CheckStatus(200).Fetch(ctx)
+		assert.NoError(t, err)
+
+		err = requests.URL(address).Path("./api/profiles/invalid-username").
+			CheckStatus(404).Fetch(ctx)
+		assert.NoError(t, err)
+	})
+
 }
 
 func getFreePort(t *testing.T) string {

--- a/cmd/app/main_test.go
+++ b/cmd/app/main_test.go
@@ -132,17 +132,6 @@ func TestRun(t *testing.T) {
 		be.Equal(t, token, res.User.Token)
 	})
 
-	t.Run("GET /api/profiles/{username}", func(t *testing.T) {
-		username := "username"
-		err := requests.URL(address).Path("./api/profiles/" + username).
-			CheckStatus(200).Fetch(ctx)
-		be.NilErr(t, err)
-
-		err = requests.URL(address).Path("./api/profiles/invalid-username").
-			CheckStatus(404).Fetch(ctx)
-		be.NilErr(t, err)
-	})
-
 }
 
 func getFreePort(t *testing.T) string {

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,9 @@ module github.com/raeperd/realworld
 go 1.22.5
 
 require (
-	github.com/alecthomas/assert/v2 v2.10.0
+	github.com/carlmjohnson/be v0.23.2
 	github.com/carlmjohnson/requests v0.24.2
 	github.com/carlmjohnson/versioninfo v0.22.5
 )
 
-require (
-	github.com/alecthomas/repr v0.4.0 // indirect
-	github.com/hexops/gotextdiff v1.0.3 // indirect
-	golang.org/x/net v0.27.0 // indirect
-)
+require golang.org/x/net v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,8 @@
-github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
-github.com/alecthomas/assert/v2 v2.10.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
-github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/carlmjohnson/be v0.23.2 h1:1QjPnPJhwGUjsD9+7h98EQlKsxnG5TV+nnEvk0wnkls=
+github.com/carlmjohnson/be v0.23.2/go.mod h1:KAgPUh0HpzWYZZI+IABdo80wTgY43YhbdsiLYAaSI/Q=
 github.com/carlmjohnson/requests v0.24.2 h1:JDakhAmTIKL/qL/1P7Kkc2INGBJIkIFP6xUeUmPzLso=
 github.com/carlmjohnson/requests v0.24.2/go.mod h1:duYA/jDnyZ6f3xbcF5PpZ9N8clgopubP2nK5i6MVMhU=
 github.com/carlmjohnson/versioninfo v0.22.5 h1:O00sjOLUAFxYQjlN/bzYTuZiS0y6fWDQjMRvwtKgwwc=
 github.com/carlmjohnson/versioninfo v0.22.5/go.mod h1:QT9mph3wcVfISUKd0i9sZfVrPviHuSF+cUtLjm2WSf8=
-github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
 golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=


### PR DESCRIPTION
Liked simplified error message from [earthboundkid/be: The Go test helper for minimalists](https://github.com/earthboundkid/be/tree/main)

## Before 
<img width="948" alt="reason to use be" src="https://github.com/user-attachments/assets/42309894-09b1-44de-a602-25942622eeb3">
<img width="1290" alt="reason-to-be" src="https://github.com/user-attachments/assets/c879f057-273c-49e6-95dd-9305d9f63df1">


## After
<img width="1526" alt="after-be" src="https://github.com/user-attachments/assets/221c66c4-abc1-4449-859e-85b40c6a49c2">

